### PR TITLE
Bind setArmPosition command to trigger

### DIFF
--- a/src/main/java/org/tahomarobotics/robot/OI.java
+++ b/src/main/java/org/tahomarobotics/robot/OI.java
@@ -35,6 +35,8 @@ import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.CommandScheduler;
 import edu.wpi.first.wpilibj2.command.Commands;
 import edu.wpi.first.wpilibj2.command.button.CommandXboxController;
+import edu.wpi.first.wpilibj2.command.button.Trigger;
+import org.tahomarobotics.robot.arm.Arm;
 import org.tinylog.Logger;
 
 import java.util.List;
@@ -42,6 +44,8 @@ import java.util.Set;
 import java.util.function.Function;
 
 public class OI {
+    // Subsystems
+    private final Arm arm;
 
     // -- Constants --
 
@@ -57,6 +61,8 @@ public class OI {
     public OI(RobotContainer robotContainer) {
         DriverStation.silenceJoystickConnectionWarning(true);
 
+        this.arm = robotContainer.arm;
+
         configureControllerBindings();
         configureLessImportantControllerBindings();
 
@@ -66,6 +72,10 @@ public class OI {
     // -- Bindings --
 
     public void configureControllerBindings() {
+        /*new Trigger(() -> Math.abs(controller.getRightY()) > DEADBAND)
+            .whileTrue(arm.setArmPosition(controller::getRightY));*/
+
+        arm.setDefaultCommand(arm.setArmPosition(controller::getRightY));
     }
 
     public void configureLessImportantControllerBindings() {
@@ -96,4 +106,6 @@ public class OI {
         value *= Math.pow(Math.abs(value), power - 1);
         return value;
     }
+
+    // TODO: Desensitize getRightY() based on deadband
 }

--- a/src/main/java/org/tahomarobotics/robot/arm/Arm.java
+++ b/src/main/java/org/tahomarobotics/robot/arm/Arm.java
@@ -3,6 +3,8 @@ package org.tahomarobotics.robot.arm;
 import edu.wpi.first.units.measure.Angle;
 import edu.wpi.first.wpilibj2.command.Command;
 
+import java.util.function.DoubleSupplier;
+
 public class Arm {
     final ArmSubsystem arm;
 
@@ -16,11 +18,15 @@ public class Arm {
 
     // Command factory methods
 
-    public Command setArmPosition(Angle position) {
-        return arm.runOnce(() -> arm.setArmPosition(position));
+    public Command setArmPosition(DoubleSupplier rightYSupplier) {
+        return arm.run(() -> arm.setArmPosition(rightYSupplier));
     }
 
     public Command setWristPosition(Angle position) {
         return arm.runOnce(() -> arm.setWristPosition(position));
+    }
+
+    public void setDefaultCommand(Command command) {
+        arm.setDefaultCommand(command);
     }
 }

--- a/src/main/java/org/tahomarobotics/robot/arm/ArmSubsystem.java
+++ b/src/main/java/org/tahomarobotics/robot/arm/ArmSubsystem.java
@@ -8,6 +8,8 @@ import org.littletonrobotics.junction.Logger;
 import org.tahomarobotics.robot.RobotMap;
 import org.tahomarobotics.robot.util.AbstractSubsystem;
 
+import java.util.function.DoubleSupplier;
+
 import static edu.wpi.first.units.Units.Degrees;
 
 public class ArmSubsystem extends AbstractSubsystem {
@@ -24,8 +26,18 @@ public class ArmSubsystem extends AbstractSubsystem {
 
     // Setters
 
-    public void setArmPosition(Angle position) {
-        armMotor.setControl(positonControl.withPosition(position));
+    public void setArmPosition(DoubleSupplier rightYSupplier) {
+        double y = rightYSupplier.getAsDouble();
+        Logger.recordOutput("Arm/Right Y Axis", y);
+
+        Angle targetPosition = armMotorPosition.getValue();
+        if (y < 0) {
+            targetPosition = Degrees.of(armMotorPosition.getValueAsDouble() + 1);
+        } else if (y > 0) {
+            targetPosition = Degrees.of(armMotorPosition.getValueAsDouble() - 1);
+        }
+        armMotor.setControl(positonControl.withPosition(targetPosition));
+        Logger.recordOutput("Arm/Target Position", targetPosition);
     }
 
     public void setWristPosition(Angle position) {


### PR DESCRIPTION
# Description
Bind setArmPosition command to trigger based on right y axis.

# Changes Made
## ArmSubsystem
Initialize position control request and status signals, add logic to setters and getters, and refresh and log status signals.

## Arm
Add command factory methods logic and add wrapper method to expose setDefaultCommand() of ArmSubsystem.

## OI
Add two ways to bind setArmPosition command to trigger.

# Why These Changes?
These changes add functionality to the arm subsystem and allow the controller to use the arm subsystem functionality.

# Testing
Gradle builds successfully and logging to AdvantageKit shows expected changes in target position value based on right y axis value.

# Checklist
- [x] Code follows project coding standards
- [x] Code builds successfully (./gradlew build)
- [x] Changes reviewed and approved