### PR TITLE
Desensitize right y axis and add logic to move wrist clockwise and counterclockwise

### DIFF
--- a/src/main/java/org/tahomarobotics/robot/OI.java
+++ b/src/main/java/org/tahomarobotics/robot/OI.java
@@ -72,7 +72,14 @@ public class OI {
     // -- Bindings --
 
     public void configureControllerBindings() {
+        // Up moves arm clockwise, down moves arm counterclockwise
         arm.setDefaultCommand(arm.setArmPosition(this::getRightY));
+
+        // Moves wrist clockwise
+        controller.rightTrigger().onTrue(arm.setWristPositionClockwise());
+
+        // Moves wrist counterclockwise
+        controller.leftTrigger().onTrue(arm.setWristPositionCounterclockwise());
     }
 
     public void configureLessImportantControllerBindings() {

--- a/src/main/java/org/tahomarobotics/robot/arm/Arm.java
+++ b/src/main/java/org/tahomarobotics/robot/arm/Arm.java
@@ -22,8 +22,12 @@ public class Arm {
         return arm.run(() -> arm.setArmPosition(rightYSupplier));
     }
 
-    public Command setWristPosition(Angle position) {
-        return arm.runOnce(() -> arm.setWristPosition(position));
+    public Command setWristPositionClockwise() {
+        return arm.runOnce(arm::setWristPositionClockwise);
+    }
+
+    public Command setWristPositionCounterclockwise() {
+        return arm.runOnce(arm::setWristPositionCounterclockwise);
     }
 
     public void setDefaultCommand(Command command) {

--- a/src/main/java/org/tahomarobotics/robot/arm/ArmConstants.java
+++ b/src/main/java/org/tahomarobotics/robot/arm/ArmConstants.java
@@ -12,4 +12,8 @@ public class ArmConstants {
     // Wrist limits
     public static final Angle WRIST_MIN_POSITION = Degrees.of(0);
     public static final Angle WRIST_MAX_POSITION = Degrees.of(300);
+
+    // Increment values
+    public static final double ARM_INCREMENT = 1;
+    public static final double WRIST_INCREMENT = 1;
 }

--- a/src/main/java/org/tahomarobotics/robot/arm/ArmSubsystem.java
+++ b/src/main/java/org/tahomarobotics/robot/arm/ArmSubsystem.java
@@ -18,7 +18,7 @@ public class ArmSubsystem extends AbstractSubsystem {
     private final TalonFX wristMotor = new TalonFX(RobotMap.WRIST_MOTOR);
 
     // Control requests
-    private final PositionVoltage positonControl = new PositionVoltage(0);
+    private final PositionVoltage positionControl = new PositionVoltage(0);
 
     // Status signals
     private final StatusSignal<Angle> armMotorPosition = armMotor.getPosition();
@@ -32,26 +32,24 @@ public class ArmSubsystem extends AbstractSubsystem {
 
         Angle targetPosition = armMotorPosition.getValue();
         if (y > 0) {
-            targetPosition = Degrees.of(armMotorPosition.getValueAsDouble() + 1);
+            targetPosition = Degrees.of(armMotorPosition.getValueAsDouble() + ArmConstants.ARM_INCREMENT);
         } else if (y < 0) {
-            targetPosition = Degrees.of(armMotorPosition.getValueAsDouble() - 1);
+            targetPosition = Degrees.of(armMotorPosition.getValueAsDouble() - ArmConstants.ARM_INCREMENT);
         }
-        armMotor.setControl(positonControl.withPosition(targetPosition));
-        Logger.recordOutput("Arm/Target Position", targetPosition);
+        armMotor.setControl(positionControl.withPosition(targetPosition));
+        Logger.recordOutput("Arm/Target Arm Position", targetPosition);
     }
 
-    public void setWristPosition(Angle position) {
-        wristMotor.setControl(positonControl.withPosition(position));
+    public void setWristPositionClockwise() {
+        Angle targetPosition = Degrees.of(wristMotorPosition.getValueAsDouble() + ArmConstants.WRIST_INCREMENT);
+        wristMotor.setControl(positionControl.withPosition(targetPosition));
+        Logger.recordOutput("Arm/Target Wrist Position", targetPosition);
     }
 
-    // Getters
-
-    public Angle getArmMotorPosition() {
-        return armMotorPosition.getValue();
-    }
-
-    public Angle getWristMotorPosition() {
-        return wristMotorPosition.getValue();
+    public void setWristPositionCounterclockwise() {
+        Angle targetPosition = Degrees.of(wristMotorPosition.getValueAsDouble() - ArmConstants.WRIST_INCREMENT);
+        wristMotor.setControl(positionControl.withPosition(targetPosition));
+        Logger.recordOutput("Arm/Target Wrist Position", targetPosition);
     }
 
     @Override
@@ -59,7 +57,7 @@ public class ArmSubsystem extends AbstractSubsystem {
         armMotorPosition.refresh();
         wristMotorPosition.refresh();
 
-        Logger.recordOutput("Arm/Arm Motor Position", getArmMotorPosition().in(Degrees));
-        Logger.recordOutput("Arm/Wrist Motor Position", getWristMotorPosition().in(Degrees));
+        Logger.recordOutput("Arm/Arm Motor Position", armMotorPosition.getValue().in(Degrees));
+        Logger.recordOutput("Arm/Wrist Motor Position", wristMotorPosition.getValue().in(Degrees));
     }
 }


### PR DESCRIPTION
# Description
Desensitize and invert right y axis value and add setters to set wrist position based on right trigger and left trigger presses.

# Why These Changes?
These changes add functionality to the wrist within the arm subsystem and allow the controller to use the wrist functionality.

# Testing
Gradle builds successfully and logging to AdvantageKit shows expected changes in target wrist position value based on right trigger and left trigger presses in simulation.

# Checklist
- [x] Code follows project coding standards
- [x] Code builds successfully (./gradlew build)
- [x] Changes reviewed and approved