### PR TITLE
Add logic for arm and wrist position limits

### DIFF
--- a/src/main/java/org/tahomarobotics/robot/arm/ArmConstants.java
+++ b/src/main/java/org/tahomarobotics/robot/arm/ArmConstants.java
@@ -6,12 +6,12 @@ import static edu.wpi.first.units.Units.Degrees;
 
 public class ArmConstants {
     // Arm limits
-    public static final Angle ARM_MIN_POSITION = Degrees.of(0);
-    public static final Angle ARM_MAX_POSITION = Degrees.of(180);
+    public static final double ARM_MIN_POSITION = 0;
+    public static final double ARM_MAX_POSITION = 180;
 
     // Wrist limits
-    public static final Angle WRIST_MIN_POSITION = Degrees.of(0);
-    public static final Angle WRIST_MAX_POSITION = Degrees.of(300);
+    public static final double WRIST_MIN_POSITION = 0;
+    public static final double WRIST_MAX_POSITION = 300;
 
     // Increment values
     public static final double ARM_INCREMENT = 1;

--- a/src/main/java/org/tahomarobotics/robot/arm/ArmSubsystem.java
+++ b/src/main/java/org/tahomarobotics/robot/arm/ArmSubsystem.java
@@ -3,6 +3,7 @@ package org.tahomarobotics.robot.arm;
 import com.ctre.phoenix6.StatusSignal;
 import com.ctre.phoenix6.controls.PositionVoltage;
 import com.ctre.phoenix6.hardware.TalonFX;
+import edu.wpi.first.math.MathUtil;
 import edu.wpi.first.units.measure.Angle;
 import org.littletonrobotics.junction.Logger;
 import org.tahomarobotics.robot.RobotMap;
@@ -30,24 +31,28 @@ public class ArmSubsystem extends AbstractSubsystem {
         double y = rightYSupplier.getAsDouble();
         Logger.recordOutput("Arm/Right Y Axis", y);
 
-        Angle targetPosition = armMotorPosition.getValue();
+        double targetPositionDouble = armMotorPosition.getValueAsDouble();
         if (y > 0) {
-            targetPosition = Degrees.of(armMotorPosition.getValueAsDouble() + ArmConstants.ARM_INCREMENT);
+            targetPositionDouble += ArmConstants.ARM_INCREMENT;
         } else if (y < 0) {
-            targetPosition = Degrees.of(armMotorPosition.getValueAsDouble() - ArmConstants.ARM_INCREMENT);
+            targetPositionDouble -= ArmConstants.ARM_INCREMENT;
         }
+
+        Angle targetPosition = Degrees.of(MathUtil.clamp(targetPositionDouble, ArmConstants.ARM_MIN_POSITION, ArmConstants.ARM_MAX_POSITION));
         armMotor.setControl(positionControl.withPosition(targetPosition));
         Logger.recordOutput("Arm/Target Arm Position", targetPosition);
     }
 
     public void setWristPositionClockwise() {
-        Angle targetPosition = Degrees.of(wristMotorPosition.getValueAsDouble() + ArmConstants.WRIST_INCREMENT);
+        double targetPositionDouble = wristMotorPosition.getValueAsDouble() + ArmConstants.WRIST_INCREMENT;
+        Angle targetPosition = Degrees.of(MathUtil.clamp(targetPositionDouble, ArmConstants.WRIST_MIN_POSITION, ArmConstants.WRIST_MAX_POSITION));
         wristMotor.setControl(positionControl.withPosition(targetPosition));
         Logger.recordOutput("Arm/Target Wrist Position", targetPosition);
     }
 
     public void setWristPositionCounterclockwise() {
-        Angle targetPosition = Degrees.of(wristMotorPosition.getValueAsDouble() - ArmConstants.WRIST_INCREMENT);
+        double targetPositionDouble = wristMotorPosition.getValueAsDouble() - ArmConstants.WRIST_INCREMENT;
+        Angle targetPosition = Degrees.of(MathUtil.clamp(targetPositionDouble, ArmConstants.WRIST_MIN_POSITION, ArmConstants.WRIST_MAX_POSITION));
         wristMotor.setControl(positionControl.withPosition(targetPosition));
         Logger.recordOutput("Arm/Target Wrist Position", targetPosition);
     }


### PR DESCRIPTION
# Description
Add logic to enforce arm and wrist position limits in setters.

# Changes Made
Change limits constants type from Angle to double and clamp target positions in arm and wrist position setters.

# Why These Changes?
These changes prevent the arm and wrist from passing their limits.

# Testing
Gradle builds successfully and logging to AdvantageKit shows expected changes in target arm and wrist position values based on controller bindings in simulation.

# Checklist
- [x] Code follows project coding standards
- [x] Code builds successfully (./gradlew build)
- [x] Changes reviewed and approved