### PR TITLE
Fix stopping elevator motors in discrete mode

### DIFF
--- a/src/main/java/org/tahomarobotics/robot/elevator/Elevator.java
+++ b/src/main/java/org/tahomarobotics/robot/elevator/Elevator.java
@@ -40,34 +40,36 @@ public class Elevator {
         return Commands.either(
             moveToBottomPositionDiscrete(),
             moveToBottomPositionContinuous(),
-            elevator.discreteMode)
-               .andThen(Commands.waitUntil(elevator::isAtTargetPosition)
-                    .andThen(Commands.runOnce(elevator::stopElevatorMotors)));
+            elevator.discreteMode);
     }
 
     public Command moveToBottomPositionDiscrete() {
-        return elevator.runOnce(elevator::moveToBottomPositionDiscrete);
+        return elevator.runOnce(elevator::moveToBottomPositionDiscrete)
+           .andThen(Commands.waitUntil(elevator::isAtTargetPosition));
     }
 
     public Command moveToBottomPositionContinuous() {
-        return elevator.runOnce(elevator::moveToBottomPositionContinuous);
+        return elevator.runOnce(elevator::moveToBottomPositionContinuous)
+           .andThen(Commands.waitUntil(elevator::isAtTargetPosition)
+                .andThen(Commands.runOnce(elevator::stopElevatorMotors)));
     }
 
     public Command moveToTopPosition() {
         return Commands.either(
            moveToTopPositionDiscrete(),
            moveToTopPositionContinuous(),
-           elevator.discreteMode)
-               .andThen(Commands.waitUntil(elevator::isAtTargetPosition)
-                    .andThen(Commands.runOnce(elevator::stopElevatorMotors)));
+           elevator.discreteMode);
     }
 
     public Command moveToTopPositionDiscrete() {
-        return elevator.runOnce(elevator::moveToTopPositionDiscrete);
+        return elevator.runOnce(elevator::moveToTopPositionDiscrete)
+           .andThen(Commands.waitUntil(elevator::isAtTargetPosition));
     }
 
     public Command moveToTopPositionContinuous() {
-        return elevator.runOnce(elevator::moveToTopPositionContinuous);
+        return elevator.runOnce(elevator::moveToTopPositionContinuous)
+           .andThen(Commands.waitUntil(elevator::isAtTargetPosition)
+                .andThen(Commands.runOnce(elevator::stopElevatorMotors)));
     }
 
     public Command toggleMode() {


### PR DESCRIPTION
### Description
Fix `Elevator::moveToBottomPosition` and `Elevator::moveToTopPosition` command factory methods stopping elevator motors in discrete mode.

### Changes Made
Refactor method chaining for `ElevatorSubsystem::isAtTargetPosition` and `ElevatorSubsystem::stopElevatorMotors` to command factory methods for readability.

### Why These Changes?
These changes ensure that the velocity of the elevator motors is not set to zero in discrete mode so that the elevator motors hold the target position.

### Testing
Gradle builds successfully and logging shows expected changes in `targetPosition` and `discreteMode`.

### Related Issues
Related to #17

### Checklist
- [x] Code follows project coding standards
- [x] Tests pass locally (./gradlew test)
- [x] Code builds successfully (./gradlew build)
- [x] Changes reviewed and approved