### PR TITLE
Fix hashtags being treated as comments

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -14,7 +14,7 @@ body:
     id: parent_epic
     attributes:
       label: Parent Epic
-      description: Link to the parent epic issue (e.g., #123).
+      description: Link to the parent epic issue (e.g., "#123").
   - type: input
     id: timeline
     attributes:

--- a/.github/ISSUE_TEMPLATE/story.yml
+++ b/.github/ISSUE_TEMPLATE/story.yml
@@ -14,7 +14,7 @@ body:
     id: parent_feature
     attributes:
       label: Parent Feature
-      description: Link to the parent feature issue (e.g., #456).
+      description: Link to the parent feature issue (e.g., "#456").
   - type: input
     id: estimate
     attributes:


### PR DESCRIPTION
## Description
<!--
Summarize the changes made in this PR. 1-2 sentences works great!

Example:
Implemented zeroing logic for collector subsystem.
-->
Escaped hashtags in section descriptions of issue templates in YAML files with double quotes.

## Why These Changes?
<!--
Explain the reasoning behind these changes:
- What problem does this solve?
- Why was this approach chosen?

Example:
These changes ensure that the collector is zeroed before setting its position.
-->
These changes ensure that the example links are rendered correctly in the issue templates.

## Testing
<!--
How have you tested these changes?
- Gradle builds without errors?
- Tested in simulation?
- Logging shows expected changes?

Example:
Code builds successfully. Logging shows `isZeroed` is true when the robot is enabled in simulation.
-->
These changes will be tested in following issues.

## Breaking Changes
<!--
Are there any changes that might make other code stop working or change how the robot behaves?
- API changes? (Did you change public method names, parameters, or return type?)
- Configuration changes? (Did you change configuration constants or CAN IDs?)
- Behavioral changes? (Does the robot behave differently?)

Examples:
1. No breaking changes.
2. Collector commands will not run until the collector is zeroed.
-->
No breaking changes.

## Related Issues
<!--
Links to any related issues.

Examples:
- Closes #issue_number
- Related to #issue_number
-->
Related to #27

## Checklist
- [x] Code follows project coding standards <!--e.g. command-based architecture, naming conventions-->
- [x] Tests pass locally (`./gradlew test`)
- [x] Code builds successfully (`./gradlew build`)
- [x] Documentation <!--comments--> updated if needed
- [x] No new linting errors <!--errors in style or formatting-->
- [x] Changes reviewed and approved